### PR TITLE
provide a relaxed tidelift config

### DIFF
--- a/.tidelift.yml
+++ b/.tidelift.yml
@@ -1,9 +1,9 @@
 # relax the tidelift configuration, so that issues that fail under normal circumstances
 # will only create a warning
-
-deprecated: warn
-vulnerable: warn
-broken: warn
+tests:
+  deprecated: warn
+  vulnerable: warn
+  broken: warn
 
 # keep the list of disallowed licenses, as suggested by Adobe Legal
 # any transitive dependency with these licenses will fail the build

--- a/.tidelift.yml
+++ b/.tidelift.yml
@@ -1,0 +1,42 @@
+# relax the tidelift configuration, so that issues that fail under normal circumstances
+# will only create a warning
+
+deprecated: warn
+vulnerable: warn
+broken: warn
+
+# keep the list of disallowed licenses, as suggested by Adobe Legal
+# any transitive dependency with these licenses will fail the build
+
+licensing:
+  disallowed:
+    - AGPL-1.0-only
+    - AGPL-1.0-or-later
+    - AGPL-3.0-only
+    - AGPL-3.0-or-later
+    - AGPL-1.0
+    - AGPL-3.0
+    - CC-BY-NC-ND-1.0
+    - CC-BY-NC-ND-2.0
+    - CC-BY-NC-ND-2.5
+    - CC-BY-NC-ND-3.0
+    - CC-BY-NC-ND-4.0
+    - CC-BY-NC-SA-1.0
+    - CC-BY-NC-SA-2.0
+    - CC-BY-NC-SA-2.5
+    - CC-BY-NC-SA-3.0
+    - CC-BY-NC-SA-4.0
+    - CC-BY-SA-1.0
+    - CC-BY-SA-2.0
+    - CC-BY-SA-2.5
+    - CC-BY-SA-3.0
+    - CC-BY-SA-4.0
+    - GPL-1.0-only
+    - GPL-1.0-or-later
+    - GPL-2.0-only
+    - GPL-2.0-or-later
+    - GPL-3.0-only
+    - GPL-3.0-or-later
+    - SSPL-1.0
+    - Sleepycat
+    - Facebook


### PR DESCRIPTION
This is an adjustment of the Tidelift config, following the documentation outlined here: https://tidelift.com/subscriber/github/adobe/repositories/aio-cli/policy/ad0df994-60eb-4ecb-91a6-eebcedfca15e

If I got it right, the branch build and the master build should stay green, but will fail when there is an unlicensed package or a package with a disallowed license in the transitive dependencies.