### PR TITLE
fix: ACNA-1865 - command_error and postrun hooks not firing

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -12,6 +12,6 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const oclif = require('@oclif/core')
-
-oclif.run().then(require('@oclif/core/flush')).catch(require('@oclif/core/handle'))
+require('../src/').run()
+  .then(require('@oclif/core/flush'))
+  .catch(require('@oclif/core/handle'))

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 Adobe Inc. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+const { Command, run, Config } = require('@oclif/core')
+
+class AIOCommand extends Command { }
+
+AIOCommand.run = async (argv, opts) => {
+  if (!argv) {
+    argv = process.argv.slice(2)
+  }
+
+  // oclif originally included the following too ...
+  // this resulted in an uncovered line in the tests, and it appeared to never happen anyway
+  // seem like it would only
+  // ||  module.parent && module.parent.parent && module.parent.parent.filename
+  const config = await Config.load(opts || __dirname)
+
+  // the second parameter is the root path to the CLI containing the command
+  try {
+    return await run(argv, config.options)
+  } catch (error) {
+    // oclif throws if the user typed --help ... ?
+    if (error.oclif && error.oclif.exit === 0) {
+      await config.runHook('postrun')
+    } else {
+      await config.runHook('command_error', { message: error.message })
+      throw (error)
+    }
+  }
+}
+
+module.exports = AIOCommand

--- a/test/hookerror.test.js
+++ b/test/hookerror.test.js
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 Adobe Inc. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+const testCommand = require('../src/index')
+
+const mockRunHook = jest.fn()
+
+class MockOclifError extends Error {
+  constructor (message) {
+    super(message)
+    this.name = 'OclifError'
+    this.oclif = { exit: 0 }
+  }
+}
+
+jest.mock('@oclif/core', () => {
+  return {
+    ...jest.requireActual('@oclif/core'),
+    Config: {
+      load: () => {
+        return {
+          runHook: mockRunHook
+        }
+      }
+    },
+    CliUx: {
+      ux: {
+        cli: {
+          open: jest.fn()
+        }
+      }
+    },
+    Command: jest.fn(),
+    run: function (cmd) {
+      if (cmd.indexOf('--help') > -1) {
+        // this error has extra props, so base command knows not to re-throw it
+        throw new MockOclifError('maybe things will turn out okay')
+      } else {
+        throw new Error('things do not look good')
+      }
+    }
+  }
+})
+
+describe('when command run throws', () => {
+  test('fire hook when command throws', async () => {
+    await expect(testCommand.run(['a', 'c', 'd'])).rejects.toThrow('things do not look good')
+    expect(mockRunHook).toHaveBeenCalledWith('command_error', expect.objectContaining({ message: 'things do not look good' }))
+  })
+
+  test('when command throws oclif-error, swallow error and fire `postrun` event :  --help', async () => {
+    await expect(testCommand.run(['a', 'c', 'd', '--help'])).resolves.toEqual(undefined)
+    expect(mockRunHook).toHaveBeenCalledWith('postrun')
+  })
+})

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 Adobe Inc. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+const testCommand = require('../src/index')
+
+jest.mock('@oclif/core', () => {
+  return {
+    ...jest.requireActual('@oclif/core'),
+    Config: {
+      load: () => ({})
+    },
+    Command: jest.fn(),
+    run: async function (cmd) {
+      return cmd
+    }
+  }
+})
+
+describe('run command', () => {
+  test('index exports a run function', async () => {
+    expect(typeof testCommand.run).toEqual('function')
+  })
+
+  test('run function returns a promise', async () => {
+    const result = testCommand.run(['a'])
+    expect(typeof result).toEqual('object')
+    expect(typeof result.then).toEqual('function')
+    expect(typeof result.catch).toEqual('function')
+  })
+
+  test('run using process.argv', async () => {
+    const temp = process.argv
+    process.argv = [0, 0, 'a']
+    const result = await testCommand.run()
+    expect(result[0]).toEqual('a')
+    process.argv = temp
+  })
+})


### PR DESCRIPTION
This is to fix the accidental deletion of the hook code from commit: https://github.com/adobe/aio-cli/commit/ae56a6a8580b410e4d45b11c4fe11fb38663b314#diff-af95cb6f5f65fe70216ddce70325e785438d5aaff956a0666ebf46ef6402f526

## How Has This Been Tested?

- npm test
- manual test of the cli

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
