### PR TITLE
fix: ACNA-2593 - support `aio -v` and `aio -h`

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,8 @@
   "license": "Apache-2.0",
   "main": "src/index.js",
   "oclif": {
+    "additionalHelpFlags": ["-h"],
+    "additionalVersionFlags": ["-v"],
     "topicSeparator": " ",
     "commands": "./src/commands",
     "bin": "aio",


### PR DESCRIPTION
Closes #434 

This was in oclif v1, but removed in oclif v2, and can be added with a oclif config change.
This helps with this failure as well: https://github.com/adobe/aio-cli/actions/runs/6540787580/job/17761310657

I will put up an aio-cli patch release for this as well after.

## How Has This Been Tested?

In the patch branch, run:
- `./bin/run -v`
- `./bin/run -h`

Verified that it doesn't work in the master branch.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
