### PR TITLE
fix: update on-push-publish-to-npm.yml

### DIFF
--- a/.github/workflows/on-push-publish-to-npm.yml
+++ b/.github/workflows/on-push-publish-to-npm.yml
@@ -19,3 +19,4 @@ jobs:
       - uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.ADOBE_BOT_NPM_TOKEN }}
+          access: 'public'


### PR DESCRIPTION
Add the parameter to the github action, so that on publish, the scope is always public.
If not, we would have to update it in npm manually from private to public, and that requires someone with npm org admin privileges.

This is not a problem if it's already public - but generally when you first publish it (especially for a new repo).
Why this PR? Since we often copy workflows from existing repos, I am adding it here to the 2 most popular repos so this issue won't happen.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
