### PR TITLE
fix: fix the aio discover command and fix the unit tests

### DIFF
--- a/src/commands/discover.js
+++ b/src/commands/discover.js
@@ -98,7 +98,7 @@ class DiscoCommand extends Command {
       // ours only, this could become a flag, searching for oclif-plugin reveals some more
       const adobeOnly = json.objects
         .map(e => e.package)
-        .filter(elem => elem.scope === 'adobe')
+        .filter(elem => elem.name && elem.name.startsWith('@adobe/aio-cli-plugin'))
 
       sortValues(adobeOnly, {
         descending: flags['sort-order'] !== 'asc',

--- a/test/commands/discover.test.js
+++ b/test/commands/discover.test.js
@@ -23,7 +23,7 @@ beforeEach(() => {
   fetch.resetMocks()
   command = new TheCommand([])
   command.config = {
-    commands: [{ pluginName: 'baz' }],
+    commands: [{ pluginName: '@adobe/aio-cli-plugin-baz' }],
     runCommand: jest.fn()
   }
 })
@@ -39,8 +39,8 @@ describe('sorting', () => {
 
   const expectedResult = {
     objects: [
-      { package: { scope: 'adobe', name: 'foo', description: 'some foo', version: '1.0.0', date: genesis } },
-      { package: { scope: 'adobe', name: 'bar', description: 'some bar', version: '1.0.1', date: later } }
+      { package: { name: '@adobe/aio-cli-plugin-a', description: 'plugin a', version: '1.0.0', date: genesis } },
+      { package: { name: '@adobe/aio-cli-plugin-b', description: 'plugin b', version: '1.0.1', date: later } }
     ]
   }
   beforeEach(() => {
@@ -59,32 +59,32 @@ describe('sorting', () => {
     command.argv = ['--sort-field', 'name', '--sort-order', 'asc']
     await command.run()
     const splitOutput = stdout.output.split('\n')
-    expect(splitOutput[2]).toMatch('bar') // bar is first
-    expect(splitOutput[3]).toMatch('foo') // foo is second
+    expect(splitOutput[2]).toMatch('@adobe/aio-cli-plugin-a') // @adobe/aio-cli-plugin-a is first
+    expect(splitOutput[3]).toMatch('@adobe/aio-cli-plugin-b') // @adobe/aio-cli-plugin-b is second
   })
 
   test('sort-field=name, descending', async () => {
     command.argv = ['--sort-field', 'name', '--sort-order', 'desc']
     await command.run()
     const splitOutput = stdout.output.split('\n')
-    expect(splitOutput[2]).toMatch('foo') // foo is first
-    expect(splitOutput[3]).toMatch('bar') // bar is second
+    expect(splitOutput[2]).toMatch('@adobe/aio-cli-plugin-b') // @adobe/aio-cli-plugin-b is first
+    expect(splitOutput[3]).toMatch('@adobe/aio-cli-plugin-a') // @adobe/aio-cli-plugin-a is second
   })
 
   test('sort-field=date, ascending', async () => {
     command.argv = ['--sort-field', 'date', '--sort-order', 'asc']
     await command.run()
     const splitOutput = stdout.output.split('\n')
-    expect(splitOutput[2]).toMatch('foo') // foo is first
-    expect(splitOutput[3]).toMatch('bar') // bar is second
+    expect(splitOutput[2]).toMatch('@adobe/aio-cli-plugin-a') // @adobe/aio-cli-plugin-a is first
+    expect(splitOutput[3]).toMatch('@adobe/aio-cli-plugin-b') // @adobe/aio-cli-plugin-b is second
   })
 
   test('sort-field=date, descending', async () => {
     command.argv = ['--sort-field', 'date', '--sort-order', 'desc']
     await command.run()
     const splitOutput = stdout.output.split('\n')
-    expect(splitOutput[2]).toMatch('bar') // bar is first
-    expect(splitOutput[3]).toMatch('foo') // foo is second
+    expect(splitOutput[2]).toMatch('@adobe/aio-cli-plugin-b') // @adobe/aio-cli-plugin-b is first
+    expect(splitOutput[3]).toMatch('@adobe/aio-cli-plugin-a') // @adobe/aio-cli-plugin-a is second
   })
 })
 
@@ -95,22 +95,22 @@ test('interactive install', async () => {
 
   const expectedResult = {
     objects: [
-      { package: { scope: 'adobe', name: 'foo', description: 'some foo', version: '1.0.0', date: now } },
-      { package: { scope: 'adobe', name: 'bar', description: 'some bar', version: '1.0.1', date: tomorrow } },
-      { package: { scope: 'adobe', name: 'baz', description: 'some baz', version: '1.0.2', date: dayAfter } }
+      { package: { name: '@adobe/aio-cli-plugin-foo', description: 'some foo', version: '1.0.0', date: now } },
+      { package: { name: '@adobe/aio-cli-plugin-bar', description: 'some bar', version: '1.0.1', date: tomorrow } },
+      { package: { name: '@adobe/aio-cli-plugin-baz', description: 'some baz', version: '1.0.2', date: dayAfter } }
     ]
   }
   fetch.mockResponseOnce(JSON.stringify(expectedResult))
 
   command.argv = ['-i']
   inquirer.prompt = jest.fn().mockResolvedValue({
-    plugins: ['bar', 'foo']
+    plugins: ['@adobe/aio-cli-plugin-bar', '@adobe/aio-cli-plugin-foo']
   })
 
   const result = await command.run()
-  expect(result).toEqual(['bar', 'foo'])
+  expect(result).toEqual(['@adobe/aio-cli-plugin-bar', '@adobe/aio-cli-plugin-foo'])
   const arg = inquirer.prompt.mock.calls[0][0] // first arg of first call
-  expect(arg[0].choices.map(elem => elem.value)).toEqual(['bar', 'foo']) // baz was an existing plugin, filtered out
+  expect(arg[0].choices.map(elem => elem.value)).toEqual(['@adobe/aio-cli-plugin-bar', '@adobe/aio-cli-plugin-foo']) // @adobe/aio-cli-plugin-baz was an existing plugin, filtered out
 })
 
 test('interactive install - no choices', async () => {
@@ -118,7 +118,7 @@ test('interactive install - no choices', async () => {
 
   const expectedResult = {
     objects: [
-      { package: { scope: 'adobe', name: 'baz', description: 'some baz', version: '1.0.2', date: now } }
+      { package: { name: '@adobe/aio-cli-plugin-baz', description: 'some baz', version: '1.0.2', date: now } }
     ]
   }
   fetch.mockResponseOnce(JSON.stringify(expectedResult))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The fix is to specifically look for packages that starts with `@adobe/aio-cli-plugin` so that only plugin packages that are explicitly tagged as AIO CLI plugins show up for the user and thus eliminating other packages like `@adobe/aio-lib-ims-oauth`, `@adobe/aio-lib-ims-jwt` etc

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

The issue was that` aio discover` command was returning an empty table because the npm registry API response structure changed- the package objects no longer contains a `scope` property that our code expects and hence the filtering returned an empty array.
Just adding a snippet of the first result for the `package` object from the response returned by the npm registry API follows this structure
```
"package": {
  "name": "@adobe/aio-cli-plugin-certificate",
  "keywords": ["oclif-plugin", "aio-cli-plugin", "ecosystem:aio-cli-plugin"],
  "version": "2.0.1",
  "description": "Generate and validate private certificates, and public key pairs for use with Adobe IO Console",
  "sanitized_name": "@adobe/aio-cli-plugin-certificate",
  "publisher": {
         "email": "grp-opensourceoffice@adobe.com",
          "username": "adobe-admin"
    },
  "maintainers": [ ... ],
  "license": "Apache-2.0",
  "date": "2024-02-08T14:59:17.603Z",
  "links": { ... }
}
```

## How Has This Been Tested?

By linking the bugfix branch and running aio discover and aio discover -i
Verifiied the commands are returning expected results
Fixed the unit tests to match the new implementation

## Screenshots (if appropriate):

`aio discover`
![Screenshot 2025-04-09 at 8 18 48 PM](https://github.com/user-attachments/assets/b24c19e1-fd00-478a-88f0-e34c2715f9fb)

`aio discover -i`
![Screenshot 2025-04-09 at 8 20 10 PM](https://github.com/user-attachments/assets/f539ffcf-bc45-4d86-a5ff-c5d7b8dd2fe7)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
