### PR TITLE
Add manifest file to support Parliament indexing

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,0 +1,7 @@
+type: navigation
+order: 1
+title: AIO-CLI user guide
+openApiEngine: stoplight
+pages:
+  - title: User Guide
+    url: README.md


### PR DESCRIPTION
Parliament is the name of our internal documentation website for developers, available at https://developers.corp.adobe.com/

We've been asked to add this body of knowledge to Ada bot's index, in order to provide automated support in the #app-builder channel in Slack.

In order to do so, we need to make these markdown pages available on Parliament. It will be onboarded on a non-discoverable (private) project, so it won't be generally available.