### PR TITLE
Fix oclif NaN error

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -13,5 +13,5 @@ governing permissions and limitations under the License.
 */
 
 require('../src/').run()
-  .then(require('@oclif/core/flush'))
+  .then(() => require('@oclif/core/flush'))
   .catch(require('@oclif/core/handle'))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Update bin/run so oclif doesn't receive a NaN when it runs during `aio app db` commands.

## Related Issue

https://jira.corp.adobe.com/browse/ACNA-4502

## Motivation and Context

Fixing NaN errors in `aio app db` with node version >=24.

## How Has This Been Tested?

Local testing comparing between NPM version and local changes.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
