### PR TITLE
fix: bin/run error handling path for oclif v4

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -19,6 +19,15 @@ governing permissions and limitations under the License.
 process.stderr.setMaxListeners(30)
 process.stdout.setMaxListeners(30)
 
+// `@oclif/core` v4 exposes `handle` and `flush` as named exports on their
+// respective subpath modules. Passing the module object (instead of the
+// function) to `Promise#catch` / `Promise#then` silently drops the
+// handler: errors escape to Node's default uncaught-exception printer
+// instead of oclif's renderer, and `flush()` is never invoked.
+// Destructure the functions explicitly so both paths run as intended.
+const { handle } = require('@oclif/core/handle')
+const { flush } = require('@oclif/core/flush')
+
 require('../src/').run()
-  .then(() => require('@oclif/core/flush'))
-  .catch(require('@oclif/core/handle'))
+  .then(flush)
+  .catch(handle)

--- a/e2e/e2e.js
+++ b/e2e/e2e.js
@@ -10,6 +10,7 @@ governing permissions and limitations under the License.
 */
 
 const execa = require('execa')
+const path = require('path')
 const fs = jest.requireActual('fs')
 const util = require('util')
 const fse = {
@@ -17,7 +18,36 @@ const fse = {
   rm: util.promisify(fs.rm)
 }
 
+const BIN_RUN = path.resolve(__dirname, '../bin/run')
+
 jest.setTimeout(120000)
+
+test('errors render through oclif, not Node\'s uncaught-exception printer', async () => {
+  // Spawns the real bin/run with an argv guaranteed to trigger a flag
+  // parse error from `@oclif/core`. When the bin's `.catch` handler is
+  // wired correctly, oclif's renderer produces a clean single-line
+  // `Error: …` message. When the handler is dropped (regression
+  // tracked in adobe/aio-cli#829 / ACNA-4659), the rejection escapes
+  // to Node and the output instead contains a source frame, a caret,
+  // a stack trace, and a `Node.js vXX` footer. Asserting on the
+  // absence of those Node-specific markers detects the regression
+  // without coupling to oclif's exact prefix.
+  const result = await execa('node', [BIN_RUN, 'app', 'use', '--no-such-flag'],
+    { reject: false })
+
+  // Non-zero exit on a parse error is part of the contract.
+  expect(result.exitCode).not.toBe(0)
+
+  // The user-facing message must be present so the customer knows what
+  // went wrong; the framework renders it on stderr.
+  expect(result.stderr).toMatch(/Nonexistent flag.*--no-such-flag/)
+
+  // None of these substrings should appear: each is a fingerprint of
+  // Node's default unhandled-rejection / uncaught-exception output.
+  expect(result.stderr).not.toMatch(/at processTicksAndRejections/)
+  expect(result.stderr).not.toMatch(/^Node\.js v\d+/m)
+  expect(result.stderr).not.toMatch(/^\s+\^\s*$/m)
+})
 
 test('cli init test', async () => {
   const testFolder = 'e2e_test_run'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`@oclif/core/handle `and `@oclif/core/flush `expose handle and flush as named exports from their subpath modules. The previous code was passing the module object directly into .then() / .catch(), which means the intended handlers were not actually being called correctly. 
As a result, errors could escape to Node’s default uncaught exception printer instead of going through oclif’s normal error renderer.

The fix explicitly destructures handle and flush and passes the actual functions into the promise chain
This keeps CLI error handling consistent and avoids leaking raw stack traces in cases where oclif should render a cleaner user-facing error.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://jira.corp.adobe.com/browse/ACNA-4659

Closes #829

## Motivation and Context

`aio` currently shows raw Node.js stack traces for CLI errors instead of oclif’s clean error output. The root cause is that `bin/run` passes the `@oclif/core/handle` and `@oclif/core/flush` module objects instead of the actual named functions exported by `@oclif/core` v4.

Because of that, error handling is skipped and user-facing validation/runtime errors are displayed as noisy stack traces. This PR fixes the wiring by passing the actual `handle` and `flush` functions, restoring clean CLI error rendering and making command failures easier to understand.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

