### PR TITLE
feat: remove unneeded npm overrides to unblock npm publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -10364,23 +10364,23 @@ Retrieves a Rule
 
 ```
 USAGE
-  $ aio rt rule get NAME [--cert] [--key] [--apiversion] [--apihost] [-u] [-i] [--debug <value>] [-v] [--version]
-    [--help]
+  $ aio rt rule get NAME [--cert <value>] [--key <value>] [--apiversion <value>] [--apihost <value>] [-u <value>]
+    [-i] [--debug <value>] [-v] [--version] [--help]
 
 ARGUMENTS
   NAME  Name of the rule
 
 FLAGS
-  -i, --insecure       bypass certificate check
-  -u, --auth           [env: WHISK_AUTH] whisk auth
-  -v, --verbose        Verbose output
-      --apihost        [env: WHISK_APIHOST] whisk API host
-      --apiversion     [env: WHISK_APIVERSION] whisk API version
-      --cert           client cert
-      --debug=<value>  Debug level output
-      --help           Show help
-      --key            client key
-      --version        Show version
+  -i, --insecure            bypass certificate check
+  -u, --auth=<value>        [env: WHISK_AUTH] whisk auth
+  -v, --verbose             Verbose output
+      --apihost=<value>     [env: WHISK_APIHOST] whisk API host
+      --apiversion=<value>  [env: WHISK_APIVERSION] whisk API version
+      --cert=<value>        client cert
+      --debug=<value>       Debug level output
+      --help                Show help
+      --key=<value>         client key
+      --version             Show version
 
 DESCRIPTION
   Retrieves a Rule
@@ -10395,26 +10395,26 @@ Retrieves a list of Rules
 
 ```
 USAGE
-  $ aio rt rule list [--cert] [--key] [--apiversion] [--apihost] [-u] [-i] [--debug <value>] [-v] [--version]
-    [--help] [-l <value>] [-s <value>] [-c] [--json] [--name-sort] [-n]
+  $ aio rt rule list [--cert <value>] [--key <value>] [--apiversion <value>] [--apihost <value>] [-u <value>] [-i]
+    [--debug <value>] [-v] [--version] [--help] [-l <value>] [-s <value>] [-c] [--json] [--name-sort] [-n]
 
 FLAGS
-  -c, --count          show only the total number of rules
-  -i, --insecure       bypass certificate check
-  -l, --limit=<value>  Limit number of rules returned (min: 0, max: 50)
-  -n, --name           sort results by name
-  -s, --skip=<value>   Skip number of rules returned
-  -u, --auth           [env: WHISK_AUTH] whisk auth
-  -v, --verbose        Verbose output
-      --apihost        [env: WHISK_APIHOST] whisk API host
-      --apiversion     [env: WHISK_APIVERSION] whisk API version
-      --cert           client cert
-      --debug=<value>  Debug level output
-      --help           Show help
-      --json           output raw json
-      --key            client key
-      --name-sort      sort results by name
-      --version        Show version
+  -c, --count               show only the total number of rules
+  -i, --insecure            bypass certificate check
+  -l, --limit=<value>       Limit number of rules returned (min: 0, max: 50)
+  -n, --name                sort results by name
+  -s, --skip=<value>        Skip number of rules returned
+  -u, --auth=<value>        [env: WHISK_AUTH] whisk auth
+  -v, --verbose             Verbose output
+      --apihost=<value>     [env: WHISK_APIHOST] whisk API host
+      --apiversion=<value>  [env: WHISK_APIVERSION] whisk API version
+      --cert=<value>        client cert
+      --debug=<value>       Debug level output
+      --help                Show help
+      --json                output raw json
+      --key=<value>         client key
+      --name-sort           sort results by name
+      --version             Show version
 
 DESCRIPTION
   Retrieves a list of Rules
@@ -10431,26 +10431,26 @@ Retrieves a list of Rules
 
 ```
 USAGE
-  $ aio rt rule ls [--cert] [--key] [--apiversion] [--apihost] [-u] [-i] [--debug <value>] [-v] [--version]
-    [--help] [-l <value>] [-s <value>] [-c] [--json] [--name-sort] [-n]
+  $ aio rt rule ls [--cert <value>] [--key <value>] [--apiversion <value>] [--apihost <value>] [-u <value>] [-i]
+    [--debug <value>] [-v] [--version] [--help] [-l <value>] [-s <value>] [-c] [--json] [--name-sort] [-n]
 
 FLAGS
-  -c, --count          show only the total number of rules
-  -i, --insecure       bypass certificate check
-  -l, --limit=<value>  Limit number of rules returned (min: 0, max: 50)
-  -n, --name           sort results by name
-  -s, --skip=<value>   Skip number of rules returned
-  -u, --auth           [env: WHISK_AUTH] whisk auth
-  -v, --verbose        Verbose output
-      --apihost        [env: WHISK_APIHOST] whisk API host
-      --apiversion     [env: WHISK_APIVERSION] whisk API version
-      --cert           client cert
-      --debug=<value>  Debug level output
-      --help           Show help
-      --json           output raw json
-      --key            client key
-      --name-sort      sort results by name
-      --version        Show version
+  -c, --count               show only the total number of rules
+  -i, --insecure            bypass certificate check
+  -l, --limit=<value>       Limit number of rules returned (min: 0, max: 50)
+  -n, --name                sort results by name
+  -s, --skip=<value>        Skip number of rules returned
+  -u, --auth=<value>        [env: WHISK_AUTH] whisk auth
+  -v, --verbose             Verbose output
+      --apihost=<value>     [env: WHISK_APIHOST] whisk API host
+      --apiversion=<value>  [env: WHISK_APIVERSION] whisk API version
+      --cert=<value>        client cert
+      --debug=<value>       Debug level output
+      --help                Show help
+      --json                output raw json
+      --key=<value>         client key
+      --name-sort           sort results by name
+      --version             Show version
 
 DESCRIPTION
   Retrieves a list of Rules
@@ -10467,23 +10467,23 @@ Gets the status of a rule
 
 ```
 USAGE
-  $ aio rt rule status NAME [--cert] [--key] [--apiversion] [--apihost] [-u] [-i] [--debug <value>] [-v] [--version]
-    [--help]
+  $ aio rt rule status NAME [--cert <value>] [--key <value>] [--apiversion <value>] [--apihost <value>] [-u <value>]
+    [-i] [--debug <value>] [-v] [--version] [--help]
 
 ARGUMENTS
   NAME  Name of the rule
 
 FLAGS
-  -i, --insecure       bypass certificate check
-  -u, --auth           [env: WHISK_AUTH] whisk auth
-  -v, --verbose        Verbose output
-      --apihost        [env: WHISK_APIHOST] whisk API host
-      --apiversion     [env: WHISK_APIVERSION] whisk API version
-      --cert           client cert
-      --debug=<value>  Debug level output
-      --help           Show help
-      --key            client key
-      --version        Show version
+  -i, --insecure            bypass certificate check
+  -u, --auth=<value>        [env: WHISK_AUTH] whisk auth
+  -v, --verbose             Verbose output
+      --apihost=<value>     [env: WHISK_APIHOST] whisk API host
+      --apiversion=<value>  [env: WHISK_APIVERSION] whisk API version
+      --cert=<value>        client cert
+      --debug=<value>       Debug level output
+      --help                Show help
+      --key=<value>         client key
+      --version             Show version
 
 DESCRIPTION
   Gets the status of a rule
@@ -10631,8 +10631,8 @@ Fire a trigger for Adobe I/O Runtime
 
 ```
 USAGE
-  $ aio rt trigger fire TRIGGERNAME [--cert] [--key] [--apiversion] [--apihost] [-u] [-i] [--debug <value>] [-v]
-    [--version] [--help] [-p <value>...] [-P <value>]
+  $ aio rt trigger fire TRIGGERNAME [--cert <value>] [--key <value>] [--apiversion <value>] [--apihost <value>] [-u
+    <value>] [-i] [--debug <value>] [-v] [--version] [--help] [-p <value>...] [-P <value>]
 
 ARGUMENTS
   TRIGGERNAME  The name of the trigger
@@ -10641,14 +10641,14 @@ FLAGS
   -P, --param-file=<value>  FILE containing parameter values in JSON format
   -i, --insecure            bypass certificate check
   -p, --param=<value>...    parameter values in KEY VALUE format
-  -u, --auth                [env: WHISK_AUTH] whisk auth
+  -u, --auth=<value>        [env: WHISK_AUTH] whisk auth
   -v, --verbose             Verbose output
-      --apihost             [env: WHISK_APIHOST] whisk API host
-      --apiversion          [env: WHISK_APIVERSION] whisk API version
-      --cert                client cert
+      --apihost=<value>     [env: WHISK_APIHOST] whisk API host
+      --apiversion=<value>  [env: WHISK_APIVERSION] whisk API version
+      --cert=<value>        client cert
       --debug=<value>       Debug level output
       --help                Show help
-      --key                 client key
+      --key=<value>         client key
       --version             Show version
 
 DESCRIPTION
@@ -10664,23 +10664,23 @@ Get a trigger for Adobe I/O Runtime
 
 ```
 USAGE
-  $ aio rt trigger get TRIGGERPATH [--cert] [--key] [--apiversion] [--apihost] [-u] [-i] [--debug <value>] [-v]
-    [--version] [--help]
+  $ aio rt trigger get TRIGGERPATH [--cert <value>] [--key <value>] [--apiversion <value>] [--apihost <value>] [-u
+    <value>] [-i] [--debug <value>] [-v] [--version] [--help]
 
 ARGUMENTS
   TRIGGERPATH  The name/path of the trigger, in the format /NAMESPACE/NAME
 
 FLAGS
-  -i, --insecure       bypass certificate check
-  -u, --auth           [env: WHISK_AUTH] whisk auth
-  -v, --verbose        Verbose output
-      --apihost        [env: WHISK_APIHOST] whisk API host
-      --apiversion     [env: WHISK_APIVERSION] whisk API version
-      --cert           client cert
-      --debug=<value>  Debug level output
-      --help           Show help
-      --key            client key
-      --version        Show version
+  -i, --insecure            bypass certificate check
+  -u, --auth=<value>        [env: WHISK_AUTH] whisk auth
+  -v, --verbose             Verbose output
+      --apihost=<value>     [env: WHISK_APIHOST] whisk API host
+      --apiversion=<value>  [env: WHISK_APIVERSION] whisk API version
+      --cert=<value>        client cert
+      --debug=<value>       Debug level output
+      --help                Show help
+      --key=<value>         client key
+      --version             Show version
 
 DESCRIPTION
   Get a trigger for Adobe I/O Runtime
@@ -10695,26 +10695,26 @@ Lists all of your triggers for Adobe I/O Runtime
 
 ```
 USAGE
-  $ aio rt trigger list [--cert] [--key] [--apiversion] [--apihost] [-u] [-i] [--debug <value>] [-v] [--version]
-    [--help] [-l <value>] [-s <value>] [-c] [--json] [--name-sort] [-n]
+  $ aio rt trigger list [--cert <value>] [--key <value>] [--apiversion <value>] [--apihost <value>] [-u <value>] [-i]
+    [--debug <value>] [-v] [--version] [--help] [-l <value>] [-s <value>] [-c] [--json] [--name-sort] [-n]
 
 FLAGS
-  -c, --count          show only the total number of triggers
-  -i, --insecure       bypass certificate check
-  -l, --limit=<value>  [default: 30] only return LIMIT number of triggers (min: 0, max: 50)
-  -n, --name           sort results by name
-  -s, --skip=<value>   exclude the first SKIP number of triggers from the result
-  -u, --auth           [env: WHISK_AUTH] whisk auth
-  -v, --verbose        Verbose output
-      --apihost        [env: WHISK_APIHOST] whisk API host
-      --apiversion     [env: WHISK_APIVERSION] whisk API version
-      --cert           client cert
-      --debug=<value>  Debug level output
-      --help           Show help
-      --json           output raw json
-      --key            client key
-      --name-sort      sort results by name
-      --version        Show version
+  -c, --count               show only the total number of triggers
+  -i, --insecure            bypass certificate check
+  -l, --limit=<value>       [default: 30] only return LIMIT number of triggers (min: 0, max: 50)
+  -n, --name                sort results by name
+  -s, --skip=<value>        exclude the first SKIP number of triggers from the result
+  -u, --auth=<value>        [env: WHISK_AUTH] whisk auth
+  -v, --verbose             Verbose output
+      --apihost=<value>     [env: WHISK_APIHOST] whisk API host
+      --apiversion=<value>  [env: WHISK_APIVERSION] whisk API version
+      --cert=<value>        client cert
+      --debug=<value>       Debug level output
+      --help                Show help
+      --json                output raw json
+      --key=<value>         client key
+      --name-sort           sort results by name
+      --version             Show version
 
 DESCRIPTION
   Lists all of your triggers for Adobe I/O Runtime
@@ -10731,26 +10731,26 @@ Lists all of your triggers for Adobe I/O Runtime
 
 ```
 USAGE
-  $ aio rt trigger ls [--cert] [--key] [--apiversion] [--apihost] [-u] [-i] [--debug <value>] [-v] [--version]
-    [--help] [-l <value>] [-s <value>] [-c] [--json] [--name-sort] [-n]
+  $ aio rt trigger ls [--cert <value>] [--key <value>] [--apiversion <value>] [--apihost <value>] [-u <value>] [-i]
+    [--debug <value>] [-v] [--version] [--help] [-l <value>] [-s <value>] [-c] [--json] [--name-sort] [-n]
 
 FLAGS
-  -c, --count          show only the total number of triggers
-  -i, --insecure       bypass certificate check
-  -l, --limit=<value>  [default: 30] only return LIMIT number of triggers (min: 0, max: 50)
-  -n, --name           sort results by name
-  -s, --skip=<value>   exclude the first SKIP number of triggers from the result
-  -u, --auth           [env: WHISK_AUTH] whisk auth
-  -v, --verbose        Verbose output
-      --apihost        [env: WHISK_APIHOST] whisk API host
-      --apiversion     [env: WHISK_APIVERSION] whisk API version
-      --cert           client cert
-      --debug=<value>  Debug level output
-      --help           Show help
-      --json           output raw json
-      --key            client key
-      --name-sort      sort results by name
-      --version        Show version
+  -c, --count               show only the total number of triggers
+  -i, --insecure            bypass certificate check
+  -l, --limit=<value>       [default: 30] only return LIMIT number of triggers (min: 0, max: 50)
+  -n, --name                sort results by name
+  -s, --skip=<value>        exclude the first SKIP number of triggers from the result
+  -u, --auth=<value>        [env: WHISK_AUTH] whisk auth
+  -v, --verbose             Verbose output
+      --apihost=<value>     [env: WHISK_APIHOST] whisk API host
+      --apiversion=<value>  [env: WHISK_APIVERSION] whisk API version
+      --cert=<value>        client cert
+      --debug=<value>       Debug level output
+      --help                Show help
+      --json                output raw json
+      --key=<value>         client key
+      --name-sort           sort results by name
+      --version             Show version
 
 DESCRIPTION
   Lists all of your triggers for Adobe I/O Runtime
@@ -14884,23 +14884,23 @@ Retrieves a Rule
 
 ```
 USAGE
-  $ aio runtime rule get NAME [--cert] [--key] [--apiversion] [--apihost] [-u] [-i] [--debug <value>] [-v] [--version]
-    [--help]
+  $ aio runtime rule get NAME [--cert <value>] [--key <value>] [--apiversion <value>] [--apihost <value>] [-u <value>]
+    [-i] [--debug <value>] [-v] [--version] [--help]
 
 ARGUMENTS
   NAME  Name of the rule
 
 FLAGS
-  -i, --insecure       bypass certificate check
-  -u, --auth           [env: WHISK_AUTH] whisk auth
-  -v, --verbose        Verbose output
-      --apihost        [env: WHISK_APIHOST] whisk API host
-      --apiversion     [env: WHISK_APIVERSION] whisk API version
-      --cert           client cert
-      --debug=<value>  Debug level output
-      --help           Show help
-      --key            client key
-      --version        Show version
+  -i, --insecure            bypass certificate check
+  -u, --auth=<value>        [env: WHISK_AUTH] whisk auth
+  -v, --verbose             Verbose output
+      --apihost=<value>     [env: WHISK_APIHOST] whisk API host
+      --apiversion=<value>  [env: WHISK_APIVERSION] whisk API version
+      --cert=<value>        client cert
+      --debug=<value>       Debug level output
+      --help                Show help
+      --key=<value>         client key
+      --version             Show version
 
 DESCRIPTION
   Retrieves a Rule
@@ -14917,26 +14917,26 @@ Retrieves a list of Rules
 
 ```
 USAGE
-  $ aio runtime rule list [--cert] [--key] [--apiversion] [--apihost] [-u] [-i] [--debug <value>] [-v] [--version]
-    [--help] [-l <value>] [-s <value>] [-c] [--json] [--name-sort] [-n]
+  $ aio runtime rule list [--cert <value>] [--key <value>] [--apiversion <value>] [--apihost <value>] [-u <value>] [-i]
+    [--debug <value>] [-v] [--version] [--help] [-l <value>] [-s <value>] [-c] [--json] [--name-sort] [-n]
 
 FLAGS
-  -c, --count          show only the total number of rules
-  -i, --insecure       bypass certificate check
-  -l, --limit=<value>  Limit number of rules returned (min: 0, max: 50)
-  -n, --name           sort results by name
-  -s, --skip=<value>   Skip number of rules returned
-  -u, --auth           [env: WHISK_AUTH] whisk auth
-  -v, --verbose        Verbose output
-      --apihost        [env: WHISK_APIHOST] whisk API host
-      --apiversion     [env: WHISK_APIVERSION] whisk API version
-      --cert           client cert
-      --debug=<value>  Debug level output
-      --help           Show help
-      --json           output raw json
-      --key            client key
-      --name-sort      sort results by name
-      --version        Show version
+  -c, --count               show only the total number of rules
+  -i, --insecure            bypass certificate check
+  -l, --limit=<value>       Limit number of rules returned (min: 0, max: 50)
+  -n, --name                sort results by name
+  -s, --skip=<value>        Skip number of rules returned
+  -u, --auth=<value>        [env: WHISK_AUTH] whisk auth
+  -v, --verbose             Verbose output
+      --apihost=<value>     [env: WHISK_APIHOST] whisk API host
+      --apiversion=<value>  [env: WHISK_APIVERSION] whisk API version
+      --cert=<value>        client cert
+      --debug=<value>       Debug level output
+      --help                Show help
+      --json                output raw json
+      --key=<value>         client key
+      --name-sort           sort results by name
+      --version             Show version
 
 DESCRIPTION
   Retrieves a list of Rules
@@ -14955,26 +14955,26 @@ Retrieves a list of Rules
 
 ```
 USAGE
-  $ aio runtime rule ls [--cert] [--key] [--apiversion] [--apihost] [-u] [-i] [--debug <value>] [-v] [--version]
-    [--help] [-l <value>] [-s <value>] [-c] [--json] [--name-sort] [-n]
+  $ aio runtime rule ls [--cert <value>] [--key <value>] [--apiversion <value>] [--apihost <value>] [-u <value>] [-i]
+    [--debug <value>] [-v] [--version] [--help] [-l <value>] [-s <value>] [-c] [--json] [--name-sort] [-n]
 
 FLAGS
-  -c, --count          show only the total number of rules
-  -i, --insecure       bypass certificate check
-  -l, --limit=<value>  Limit number of rules returned (min: 0, max: 50)
-  -n, --name           sort results by name
-  -s, --skip=<value>   Skip number of rules returned
-  -u, --auth           [env: WHISK_AUTH] whisk auth
-  -v, --verbose        Verbose output
-      --apihost        [env: WHISK_APIHOST] whisk API host
-      --apiversion     [env: WHISK_APIVERSION] whisk API version
-      --cert           client cert
-      --debug=<value>  Debug level output
-      --help           Show help
-      --json           output raw json
-      --key            client key
-      --name-sort      sort results by name
-      --version        Show version
+  -c, --count               show only the total number of rules
+  -i, --insecure            bypass certificate check
+  -l, --limit=<value>       Limit number of rules returned (min: 0, max: 50)
+  -n, --name                sort results by name
+  -s, --skip=<value>        Skip number of rules returned
+  -u, --auth=<value>        [env: WHISK_AUTH] whisk auth
+  -v, --verbose             Verbose output
+      --apihost=<value>     [env: WHISK_APIHOST] whisk API host
+      --apiversion=<value>  [env: WHISK_APIVERSION] whisk API version
+      --cert=<value>        client cert
+      --debug=<value>       Debug level output
+      --help                Show help
+      --json                output raw json
+      --key=<value>         client key
+      --name-sort           sort results by name
+      --version             Show version
 
 DESCRIPTION
   Retrieves a list of Rules
@@ -14991,23 +14991,23 @@ Gets the status of a rule
 
 ```
 USAGE
-  $ aio runtime rule status NAME [--cert] [--key] [--apiversion] [--apihost] [-u] [-i] [--debug <value>] [-v] [--version]
-    [--help]
+  $ aio runtime rule status NAME [--cert <value>] [--key <value>] [--apiversion <value>] [--apihost <value>] [-u <value>]
+    [-i] [--debug <value>] [-v] [--version] [--help]
 
 ARGUMENTS
   NAME  Name of the rule
 
 FLAGS
-  -i, --insecure       bypass certificate check
-  -u, --auth           [env: WHISK_AUTH] whisk auth
-  -v, --verbose        Verbose output
-      --apihost        [env: WHISK_APIHOST] whisk API host
-      --apiversion     [env: WHISK_APIVERSION] whisk API version
-      --cert           client cert
-      --debug=<value>  Debug level output
-      --help           Show help
-      --key            client key
-      --version        Show version
+  -i, --insecure            bypass certificate check
+  -u, --auth=<value>        [env: WHISK_AUTH] whisk auth
+  -v, --verbose             Verbose output
+      --apihost=<value>     [env: WHISK_APIHOST] whisk API host
+      --apiversion=<value>  [env: WHISK_APIVERSION] whisk API version
+      --cert=<value>        client cert
+      --debug=<value>       Debug level output
+      --help                Show help
+      --key=<value>         client key
+      --version             Show version
 
 DESCRIPTION
   Gets the status of a rule
@@ -15165,8 +15165,8 @@ Fire a trigger for Adobe I/O Runtime
 
 ```
 USAGE
-  $ aio runtime trigger fire TRIGGERNAME [--cert] [--key] [--apiversion] [--apihost] [-u] [-i] [--debug <value>] [-v]
-    [--version] [--help] [-p <value>...] [-P <value>]
+  $ aio runtime trigger fire TRIGGERNAME [--cert <value>] [--key <value>] [--apiversion <value>] [--apihost <value>] [-u
+    <value>] [-i] [--debug <value>] [-v] [--version] [--help] [-p <value>...] [-P <value>]
 
 ARGUMENTS
   TRIGGERNAME  The name of the trigger
@@ -15175,14 +15175,14 @@ FLAGS
   -P, --param-file=<value>  FILE containing parameter values in JSON format
   -i, --insecure            bypass certificate check
   -p, --param=<value>...    parameter values in KEY VALUE format
-  -u, --auth                [env: WHISK_AUTH] whisk auth
+  -u, --auth=<value>        [env: WHISK_AUTH] whisk auth
   -v, --verbose             Verbose output
-      --apihost             [env: WHISK_APIHOST] whisk API host
-      --apiversion          [env: WHISK_APIVERSION] whisk API version
-      --cert                client cert
+      --apihost=<value>     [env: WHISK_APIHOST] whisk API host
+      --apiversion=<value>  [env: WHISK_APIVERSION] whisk API version
+      --cert=<value>        client cert
       --debug=<value>       Debug level output
       --help                Show help
-      --key                 client key
+      --key=<value>         client key
       --version             Show version
 
 DESCRIPTION
@@ -15200,23 +15200,23 @@ Get a trigger for Adobe I/O Runtime
 
 ```
 USAGE
-  $ aio runtime trigger get TRIGGERPATH [--cert] [--key] [--apiversion] [--apihost] [-u] [-i] [--debug <value>] [-v]
-    [--version] [--help]
+  $ aio runtime trigger get TRIGGERPATH [--cert <value>] [--key <value>] [--apiversion <value>] [--apihost <value>] [-u
+    <value>] [-i] [--debug <value>] [-v] [--version] [--help]
 
 ARGUMENTS
   TRIGGERPATH  The name/path of the trigger, in the format /NAMESPACE/NAME
 
 FLAGS
-  -i, --insecure       bypass certificate check
-  -u, --auth           [env: WHISK_AUTH] whisk auth
-  -v, --verbose        Verbose output
-      --apihost        [env: WHISK_APIHOST] whisk API host
-      --apiversion     [env: WHISK_APIVERSION] whisk API version
-      --cert           client cert
-      --debug=<value>  Debug level output
-      --help           Show help
-      --key            client key
-      --version        Show version
+  -i, --insecure            bypass certificate check
+  -u, --auth=<value>        [env: WHISK_AUTH] whisk auth
+  -v, --verbose             Verbose output
+      --apihost=<value>     [env: WHISK_APIHOST] whisk API host
+      --apiversion=<value>  [env: WHISK_APIVERSION] whisk API version
+      --cert=<value>        client cert
+      --debug=<value>       Debug level output
+      --help                Show help
+      --key=<value>         client key
+      --version             Show version
 
 DESCRIPTION
   Get a trigger for Adobe I/O Runtime
@@ -15233,26 +15233,26 @@ Lists all of your triggers for Adobe I/O Runtime
 
 ```
 USAGE
-  $ aio runtime trigger list [--cert] [--key] [--apiversion] [--apihost] [-u] [-i] [--debug <value>] [-v] [--version]
-    [--help] [-l <value>] [-s <value>] [-c] [--json] [--name-sort] [-n]
+  $ aio runtime trigger list [--cert <value>] [--key <value>] [--apiversion <value>] [--apihost <value>] [-u <value>] [-i]
+    [--debug <value>] [-v] [--version] [--help] [-l <value>] [-s <value>] [-c] [--json] [--name-sort] [-n]
 
 FLAGS
-  -c, --count          show only the total number of triggers
-  -i, --insecure       bypass certificate check
-  -l, --limit=<value>  [default: 30] only return LIMIT number of triggers (min: 0, max: 50)
-  -n, --name           sort results by name
-  -s, --skip=<value>   exclude the first SKIP number of triggers from the result
-  -u, --auth           [env: WHISK_AUTH] whisk auth
-  -v, --verbose        Verbose output
-      --apihost        [env: WHISK_APIHOST] whisk API host
-      --apiversion     [env: WHISK_APIVERSION] whisk API version
-      --cert           client cert
-      --debug=<value>  Debug level output
-      --help           Show help
-      --json           output raw json
-      --key            client key
-      --name-sort      sort results by name
-      --version        Show version
+  -c, --count               show only the total number of triggers
+  -i, --insecure            bypass certificate check
+  -l, --limit=<value>       [default: 30] only return LIMIT number of triggers (min: 0, max: 50)
+  -n, --name                sort results by name
+  -s, --skip=<value>        exclude the first SKIP number of triggers from the result
+  -u, --auth=<value>        [env: WHISK_AUTH] whisk auth
+  -v, --verbose             Verbose output
+      --apihost=<value>     [env: WHISK_APIHOST] whisk API host
+      --apiversion=<value>  [env: WHISK_APIVERSION] whisk API version
+      --cert=<value>        client cert
+      --debug=<value>       Debug level output
+      --help                Show help
+      --json                output raw json
+      --key=<value>         client key
+      --name-sort           sort results by name
+      --version             Show version
 
 DESCRIPTION
   Lists all of your triggers for Adobe I/O Runtime
@@ -15271,26 +15271,26 @@ Lists all of your triggers for Adobe I/O Runtime
 
 ```
 USAGE
-  $ aio runtime trigger ls [--cert] [--key] [--apiversion] [--apihost] [-u] [-i] [--debug <value>] [-v] [--version]
-    [--help] [-l <value>] [-s <value>] [-c] [--json] [--name-sort] [-n]
+  $ aio runtime trigger ls [--cert <value>] [--key <value>] [--apiversion <value>] [--apihost <value>] [-u <value>] [-i]
+    [--debug <value>] [-v] [--version] [--help] [-l <value>] [-s <value>] [-c] [--json] [--name-sort] [-n]
 
 FLAGS
-  -c, --count          show only the total number of triggers
-  -i, --insecure       bypass certificate check
-  -l, --limit=<value>  [default: 30] only return LIMIT number of triggers (min: 0, max: 50)
-  -n, --name           sort results by name
-  -s, --skip=<value>   exclude the first SKIP number of triggers from the result
-  -u, --auth           [env: WHISK_AUTH] whisk auth
-  -v, --verbose        Verbose output
-      --apihost        [env: WHISK_APIHOST] whisk API host
-      --apiversion     [env: WHISK_APIVERSION] whisk API version
-      --cert           client cert
-      --debug=<value>  Debug level output
-      --help           Show help
-      --json           output raw json
-      --key            client key
-      --name-sort      sort results by name
-      --version        Show version
+  -c, --count               show only the total number of triggers
+  -i, --insecure            bypass certificate check
+  -l, --limit=<value>       [default: 30] only return LIMIT number of triggers (min: 0, max: 50)
+  -n, --name                sort results by name
+  -s, --skip=<value>        exclude the first SKIP number of triggers from the result
+  -u, --auth=<value>        [env: WHISK_AUTH] whisk auth
+  -v, --verbose             Verbose output
+      --apihost=<value>     [env: WHISK_APIHOST] whisk API host
+      --apiversion=<value>  [env: WHISK_APIVERSION] whisk API version
+      --cert=<value>        client cert
+      --debug=<value>       Debug level output
+      --help                Show help
+      --json                output raw json
+      --key=<value>         client key
+      --name-sort           sort results by name
+      --version             Show version
 
 DESCRIPTION
   Lists all of your triggers for Adobe I/O Runtime

--- a/package-lock.json
+++ b/package-lock.json
@@ -4580,6 +4580,7 @@
       "resolved": "https://registry.npmjs.org/@adobe/aio-lib-ims/-/aio-lib-ims-7.0.2.tgz",
       "integrity": "sha512-H4LK6fVcADPpnD6lZIzfosBAkHyOW1Yluk7MnNGs5TKM41i3NGGl/GaI/oQjDQGH4pIISK7HPU6FO0M+0+w04g==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@adobe/aio-lib-core-config": "^5",
         "@adobe/aio-lib-core-errors": "^4",
@@ -11822,19 +11823,6 @@
         "node": "^18 || ^20 || >= 21"
       }
     },
-    "node_modules/@swagger-api/apidom-parser-adapter-yaml-1-2/node_modules/tree-sitter": {
-      "version": "0.22.4",
-      "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.22.4.tgz",
-      "integrity": "sha512-usbHZP9/oxNsUY65MQUsduGRqDHQOou1cagUSwjhoSYAmSahjQDAVsh9s+SlZkn8X8+O1FULRGwHu7AFP3kjzg==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-addon-api": "^8.3.0",
-        "node-gyp-build": "^4.8.4"
-      }
-    },
     "node_modules/@swagger-api/apidom-reference": {
       "version": "1.11.2",
       "resolved": "https://registry.npmjs.org/@swagger-api/apidom-reference/-/apidom-reference-1.11.2.tgz",
@@ -12169,15 +12157,6 @@
       },
       "engines": {
         "node": ">=14.16"
-      }
-    },
-    "node_modules/@tootallnate/once": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-3.0.1.tgz",
-      "integrity": "sha512-VyMVKRrpHTT8PnotUeV8L/mDaMwD5DaAKCFLP73zAqAtvF0FCqky+Ki7BYbFCYQmqFyTe9316Ed5zS70QUR9eg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/@tootallnate/quickjs-emscripten": {
@@ -17646,12 +17625,15 @@
       }
     },
     "node_modules/external-editor/node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "license": "MIT",
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
       "engines": {
-        "node": ">=14.14"
+        "node": ">=0.6.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -25642,6 +25624,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/own-keys": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
@@ -31347,6 +31338,15 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/yeoman-generator/node_modules/@tootallnate/once": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/yeoman-generator/node_modules/@tufjs/canonical-json": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@tufjs/canonical-json/-/canonical-json-1.0.0.tgz",
@@ -31769,23 +31769,6 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/yeoman-generator/node_modules/mem-fs": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/mem-fs/-/mem-fs-2.3.0.tgz",
-      "integrity": "sha512-GftCCBs6EN8sz3BoWO1bCj8t7YBtT713d8bUgbhg9Iel5kFSqnSvCK06TYIDJAtJ51cSiWkM/YemlT0dfoFycw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/node": "^15.6.2",
-        "@types/vinyl": "^2.0.4",
-        "vinyl": "^2.0.1",
-        "vinyl-file": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/yeoman-generator/node_modules/mem-fs-editor": {

--- a/package.json
+++ b/package.json
@@ -128,12 +128,8 @@
   "overrides": {
     "tar": "^7.4.3",
     "@octokit/rest": "^20.0.2",
-    "@tootallnate/once": "3.0.1",
     "@yeoman/conflicter": {
       "diff": "^8.0.4"
-    },
-    "external-editor": {
-      "tmp": "0.2.5"
     }
   },
   "repository": "adobe/aio-cli",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- newly added check-overrides.js script is now gating the publish and checks for any npm overrides in the package.json. So those two stale override entries need be removed before it can be released

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- Ran. `npm run check-overrides`
   - Removed those two stale entries from package.json
- Re ran npm install 
- re ran npm test
## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
